### PR TITLE
Separate server bootstrap sequence between `listen()` and `run()`

### DIFF
--- a/e2e-test/src/test.rs
+++ b/e2e-test/src/test.rs
@@ -78,9 +78,9 @@ mod tests {
     use radius::core::code::Code;
     use radius::core::packet::Packet;
     use radius::core::rfc2865;
-    use radius::server::Server;
 
     use crate::test::{LongTimeTakingHandler, MyRequestHandler, MySecretProvider};
+    use radius::server::Server;
 
     #[tokio::test]
     async fn test_runner() {
@@ -93,18 +93,19 @@ mod tests {
 
         let port = 1812;
 
+        let mut server = Server::listen(
+            "0.0.0.0",
+            port,
+            1500,
+            true,
+            MyRequestHandler {},
+            MySecretProvider {},
+        )
+        .await
+        .unwrap();
+
         let server_proc = tokio::spawn(async move {
-            Server::run(
-                "0.0.0.0",
-                port,
-                1500,
-                true,
-                MyRequestHandler {},
-                MySecretProvider {},
-                receiver,
-            )
-            .await
-            .unwrap();
+            server.run(receiver).await.unwrap();
         });
 
         let remote_addr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();
@@ -136,18 +137,19 @@ mod tests {
 
         let port = 1812;
 
+        let mut server = Server::listen(
+            "0.0.0.0",
+            port,
+            1500,
+            true,
+            LongTimeTakingHandler {},
+            MySecretProvider {},
+        )
+        .await
+        .unwrap();
+
         let server_proc = tokio::spawn(async move {
-            Server::run(
-                "0.0.0.0",
-                port,
-                1500,
-                true,
-                LongTimeTakingHandler {},
-                MySecretProvider {},
-                receiver,
-            )
-            .await
-            .unwrap();
+            server.run(receiver).await.unwrap();
         });
 
         let remote_addr: SocketAddr = format!("127.0.0.1:{}", port).parse().unwrap();

--- a/e2e-test/src/test.rs
+++ b/e2e-test/src/test.rs
@@ -93,16 +93,9 @@ mod tests {
 
         let port = 1812;
 
-        let mut server = Server::listen(
-            "0.0.0.0",
-            port,
-            1500,
-            true,
-            MyRequestHandler {},
-            MySecretProvider {},
-        )
-        .await
-        .unwrap();
+        let mut server = Server::listen("0.0.0.0", port, MyRequestHandler {}, MySecretProvider {})
+            .await
+            .unwrap();
 
         let server_proc = tokio::spawn(async move {
             server.run(receiver).await.unwrap();
@@ -140,8 +133,6 @@ mod tests {
         let mut server = Server::listen(
             "0.0.0.0",
             port,
-            1500,
-            true,
             LongTimeTakingHandler {},
             MySecretProvider {},
         )

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -18,16 +18,11 @@ async fn main() {
     env_logger::init();
 
     // start UDP listening
-    let mut server = Server::listen(
-        "0.0.0.0",
-        1812,
-        1500,
-        false,
-        MyRequestHandler {},
-        MySecretProvider {},
-    )
-    .await
-    .unwrap();
+    let mut server = Server::listen("0.0.0.0", 1812, MyRequestHandler {}, MySecretProvider {})
+        .await
+        .unwrap();
+    server.set_buffer_size(1500); // default value: 1500
+    server.set_skip_authenticity_validation(false); // default value: false
 
     // once it has reached here, a RADIUS server is now ready
     info!(


### PR DESCRIPTION
# BREAKING CHANGES

## Separate server bootstrap sequence between `listen()` and `run()`
Initially, it attempted to use a channel that given through the `run()` parameter to notify when a server becomes ready, but that doesn't work because it never runs the procedure until `await` called.
This means if it calls `await`, it blocks the procedure so it cannot consume a channel simultaneously.

Thus, it separates bootstrap sequence between `listen()` and `run()`.
- `listen()`: Start UDP listening. After this function call is finished, the RADIUS server is ready.
- `run()`: Start a loop to handle the RADIUS requests.

## Set parameters by setters, instead of function parameters

- buffer_size: `Server#set_buffer_size(usize)`
- skip_authenticity_validation: `Server#set_skip_authenticity_validation(bool)`