### PR TITLE
Add AccountingResponse to set of known codes for encode

### DIFF
--- a/radius/src/core/packet.rs
+++ b/radius/src/core/packet.rs
@@ -170,6 +170,7 @@ impl Packet {
             Code::AccessAccept
             | Code::AccessReject
             | Code::AccountingRequest
+            | Code::AccountingResponse
             | Code::AccessChallenge
             | Code::DisconnectRequest
             | Code::DisconnectACK


### PR DESCRIPTION
Ran into UnknownCode when trying to encode Accounting Responses.