### PR TITLE
Initial Scaffold for EAP Messages

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -21,3 +21,7 @@ path = "server.rs"
 name = "client"
 path = "client.rs"
 
+[[example]]
+name = "eap_server"
+path = "eap_server.rs"
+

--- a/examples/eap_server.rs
+++ b/examples/eap_server.rs
@@ -1,0 +1,111 @@
+#[macro_use]
+extern crate log;
+
+use std::net::SocketAddr;
+use std::{io, process};
+
+use async_trait::async_trait;
+use tokio::net::UdpSocket;
+use tokio::signal;
+
+use radius::core::code::Code;
+use radius::core::request::Request;
+use radius::core::eap::EAP;
+use radius::core::rfc2865;
+use radius::core::rfc2869;
+use radius::server::{RequestHandler, SecretProvider, SecretProviderError, Server};
+
+#[tokio::main]
+async fn main() {
+    env_logger::init();
+
+    // start UDP listening
+    let mut server = Server::listen("0.0.0.0", 1812, MyRequestHandler {}, MySecretProvider {})
+        .await
+        .unwrap();
+    server.set_buffer_size(1500); // default value: 1500
+    server.set_skip_authenticity_validation(false); // default value: false
+
+    // once it has reached here, a RADIUS server is now ready
+    info!(
+        "serve is now ready: {}",
+        server.get_listen_address().unwrap()
+    );
+
+    // start the loop to handle the RADIUS requests
+    let result = server.run(signal::ctrl_c()).await;
+    info!("{:?}", result);
+    if result.is_err() {
+        process::exit(1);
+    }
+}
+
+struct MyRequestHandler {}
+
+#[async_trait]
+impl RequestHandler<(), io::Error> for MyRequestHandler {
+    async fn handle_radius_request(
+        &self,
+        conn: &UdpSocket,
+        req: &Request,
+    ) -> Result<(), io::Error> {
+        let req_packet = req.get_packet();
+        // println!("Req:\n{:#?}", req_packet.clone());
+        let maybe_user_name_attr = rfc2865::lookup_user_name(req_packet);
+        let maybe_user_password_attr = rfc2865::lookup_user_password(req_packet);
+        info!("maybe usr pass looked up");
+        let maybe_eap_message = rfc2869::lookup_eap_message(req_packet);
+        info!("maybe eap looked up");
+        let eap_message = match maybe_eap_message {
+            Some(e) => EAP::from_bytes(&e),
+            None => {
+                println!("No eap message found");
+                EAP::new()
+            }
+        };
+        println!("EAP Message: {}", &eap_message);
+        let maybe_message_authenticator = rfc2869::lookup_message_authenticator(req_packet);
+        match maybe_message_authenticator {
+            Some(m) => println!("Found authenticator:\n{:#?}\n",m),
+            None => println!("No authenticator found")
+        }
+
+        let user_name = maybe_user_name_attr.unwrap().unwrap();
+        let user_password = match maybe_user_password_attr {
+            Some(e) => match e {
+                Ok(m) => String::from_utf8(m).unwrap(),
+                Err(e) => {
+                    error!("Could not decode user password due to:\n{}\n", e);
+                    "".to_owned()
+                }
+            },
+            None => {
+                info!("No user password found");
+                "".to_owned()
+            }
+        };
+
+        let code = if user_name == "admin" && user_password == "p@ssw0rd" {
+            Code::AccessAccept
+        } else {
+            Code::AccessReject
+        };
+        info!("response => {:?} to {}", code, req.get_remote_addr());
+
+        conn.send_to(
+            &req_packet.make_response_packet(code).encode().unwrap(),
+            req.get_remote_addr(),
+        )
+        .await?;
+        Ok(())
+    }
+}
+
+struct MySecretProvider {}
+
+impl SecretProvider for MySecretProvider {
+    fn fetch_secret(&self, _remote_addr: SocketAddr) -> Result<Vec<u8>, SecretProviderError> {
+        let bs = b"secret".to_vec();
+        Ok(bs)
+    }
+}

--- a/radius/src/core/eap.rs
+++ b/radius/src/core/eap.rs
@@ -1,0 +1,193 @@
+use std::fmt;
+use std::convert::TryFrom;
+use num_enum::TryFromPrimitive;
+///! From https://datatracker.ietf.org/doc/html/rfc2284
+/// 
+// A summary of the Request and Response packet format is shown below.
+// The fields are transmitted from left to right.
+//  0                   1                   2                   3
+//  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     Code      |  Identifier   |            Length             |
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+// |     Type      |  Type-Data ...
+// +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+// Code
+//    1 for Request;
+//    2 for Response.
+// Identifier
+//    The Identifier field is one octet.  The Identifier field MUST be
+//    the same if a Request packet is retransmitted due to a timeout
+//    while waiting for a Response.  Any new (non-retransmission)
+//    Requests MUST modify the Identifier field.  If a peer recieves a
+//    duplicate Request for which it has already sent a Response, it
+//    MUST resend it's Response.  If a peer receives a duplicate Request
+//    before it has sent a Response to the initial Request (i.e. it's
+//    waiting for user input), it MUST silently discard the duplicate
+//    Request.
+// Length
+//    The Length field is two octets and indicates the length of the EAP
+//    packet including the Code, Identifier, Length, Type, and Type-Data
+//    fields.  Octets outside the range of the Length field should be
+//    treated as Data Link Layer padding and should be ignored on
+//    reception.
+// Type
+//    The Type field is one octet.  This field indicates the Type of
+//    Request or Response.  Only one Type MUST be specified per EAP
+//    Request or Response.  Normally, the Type field of the Response
+//    will be the same as the Type of the Request.  However, there is
+//    also a Nak Response Type for indicating that a Request type is
+//    unacceptable to the peer.  When sending a Nak in response to a
+//    Request, the peer MAY indicate an alternative desired
+//    authentication Type which it supports. An initial specification of
+//    Types follows in a later section of this document.
+// Type-Data
+//    The Type-Data field varies with the Type of Request and the
+//    associated Response.
+///!
+///!
+///! From https://datatracker.ietf.org/doc/html/rfc3579#page-14
+//    Where the NAS sends an EAP-Request/Identity as the initial packet,
+//    the exchange appears as follows:
+// Authenticating peer     NAS                    RADIUS server
+// -------------------     ---                    -------------
+//                         <- EAP-Request/
+//                         Identity
+// EAP-Response/
+// Identity (MyID) ->
+//                         RADIUS Access-Request/
+//                         EAP-Message/EAP-Response/
+//                         (MyID) ->
+//                                                <- RADIUS
+//                                                Access-Challenge/
+//                                                EAP-Message/EAP-Request
+//                                                OTP/OTP Challenge
+//                         <- EAP-Request/
+//                         OTP/OTP Challenge
+// EAP-Response/
+// OTP, OTPpw ->
+//                         RADIUS Access-Request/
+//                         EAP-Message/EAP-Response/
+//                         OTP, OTPpw ->
+//                                                 <- RADIUS
+//                                                 Access-Accept/
+//                                                 EAP-Message/EAP-Success
+//                                                 (other attributes)
+//                         <- EAP-Success
+///!
+#[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
+pub enum EAPCode {
+    Request = 1,
+    Response = 2,
+    Invalid = 0,
+}
+
+impl EAPCode {
+    pub fn string(&self) -> &'static str {
+        match self {
+            EAPCode::Request => "EAP-Request",
+            EAPCode::Response => "EAP-Response",
+            EAPCode::Invalid => "EAP-Invalid"
+        }
+    }
+    pub fn from(value: u8) -> Self {
+        match EAPCode::try_from(value) {
+            Ok(code) => code,
+            Err(_) => EAPCode::Invalid,
+        }
+    }
+}
+//
+// This section defines the initial set of EAP Types used in
+// Request/Response exchanges.  More Types may be defined in follow-on
+// documents.  The Type field is one octet and identifies the structure
+// of an EAP Request or Response packet.  The first 3 Types are
+// considered special case Types.  The remaining Types define
+// authentication exchanges.  The Nak Type is valid only for Response
+// packets, it MUST NOT be sent in a Request.  The Nak Type MUST only be
+// sent in repsonse to a Request which uses an authentication Type code.
+// All EAP implementatins MUST support Types 1-4.  These Types, as well
+// as types 5 and 6, are defined in this document.  Follow-on RFCs will
+// define additional EAP Types.
+
+//    1       Identity
+//    2       Notification
+//    3       Nak (Response only)
+//    4       MD5-Challenge
+//    5       One-Time Password (OTP) (RFC 1938)
+//    6       Generic Token Card
+//
+#[derive(Debug, Copy, Clone, PartialEq, TryFromPrimitive)]
+#[repr(u8)]
+pub enum EAPType {
+    Identity = 1,
+    Notification = 2,
+    Nak = 3,
+    MD5Challenge = 4,
+    OneTimePass = 5,
+    TokenCard = 6,
+    Invalid = 0
+}
+
+impl EAPType {
+    pub fn string(&self) -> &'static str {
+        match self {
+            EAPType::Identity => "EAP-Identity",
+            EAPType::Notification => "EAP-Notification",
+            EAPType::Nak => "EAP-Nak",
+            EAPType::MD5Challenge => "EAP-MD5Challenge",
+            EAPType::OneTimePass => "EAP-OneTimePass",
+            EAPType::TokenCard => "EAP-TokenCard",
+            EAPType::Invalid => "EAP-Invalid",
+        }
+    }
+    pub fn from(value: u8) -> Self {
+        match EAPType::try_from(value) {
+            Ok(code) => code,
+            Err(_) => EAPType::Invalid,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct EAP {
+    pub code: EAPCode,
+    pub id: u8,
+    pub len: u16,
+    pub typ: EAPType,
+    pub data: Vec<u8>
+}
+
+impl EAP {
+    pub fn new() -> Self {
+        EAP {
+            code: EAPCode::from(0),
+            id: 0,
+            len: 0,
+            typ: EAPType::from(0),
+            data: vec![]
+        }
+    }
+    pub fn from_bytes(eap_bytes: &[u8]) -> Self {
+        let code = EAPCode::from(eap_bytes[0]);
+        let id   = eap_bytes[1].to_owned();
+        let len  = Self::len_from_bytes(&eap_bytes[2..4]);
+        let typ = EAPType::from(eap_bytes[4]);
+        let data = eap_bytes[5..len as usize].to_owned();
+        EAP { code, id, len, typ, data }
+    }
+    fn len_from_bytes(bytes: &[u8]) -> u16 {
+        ((bytes[0] as u16) << 8) | bytes[1] as u16
+    }
+}
+
+impl fmt::Display for EAP {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "Code: {}, ID: {}, Length: {}, Type: {}, Data Length: {}",
+            self.code.string(), self.id, self.len, self.typ.string(), self.data.len()
+        )
+    }
+}

--- a/radius/src/core/mod.rs
+++ b/radius/src/core/mod.rs
@@ -30,3 +30,4 @@ pub mod rfc6911;
 pub mod rfc7055;
 pub mod rfc7155;
 pub mod tag;
+pub mod eap;


### PR DESCRIPTION
Implement EAP struct with Enums defined from RFC2284 and RFC3579.
Implement basic parsing of data into the struct and human-readable
output of contents.

---

This is very much WIP, seeking to address #32, working off of dry RFCs trying to put them together into something coherent for `struct`s and `impl`s. 
TODO's for MVP:
- [ ] MD5 Message Authenticator generation & validation
- [ ] EAP transaction state management (this merits discussion as state handling is generally done in the `server` but message identifiers in EAP segments have to be deconflicted)
- [ ] Identity access-request/eap-response
- [ ] MD5-Challenge authentication
TODO's for completion:
- [ ] OTP authentication
- [ ] SmartCard authentication

---
Testing:
  Using `radtest -t eap-md5 test me localhost 1 somesecretval` i am seeing proper output for the EAP packet fields in
  ```rust
$ target/debug/examples/server
EAP Message: Code: EAP-Response, ID: 114, Length: 9, Type: EAP-Identity, Data Length: 4
Found authenticator:
[
    252,
    83,
    114,
    108,
    37,
    126,
    67,
    232,
    150,
    151,
    217,
    166,
    4,
    83,
    120,
    138,
]
```