### PR TITLE
Handling of Vendor Specific Attributes (VSA)

### DIFF
--- a/radius/src/core/mod.rs
+++ b/radius/src/core/mod.rs
@@ -30,3 +30,4 @@ pub mod rfc6911;
 pub mod rfc7055;
 pub mod rfc7155;
 pub mod tag;
+pub mod vsa;

--- a/radius/src/core/rfc2865.rs
+++ b/radius/src/core/rfc2865.rs
@@ -150,6 +150,7 @@ use std::net::Ipv4Addr;
 
 use crate::core::avp::{AVPError, AVPType, AVP};
 use crate::core::packet::Packet;
+use crate::core::vsa::VSA;
 
 pub const USER_NAME_TYPE: AVPType = 1;
 /// Delete all of `user_name` values from a packet.
@@ -355,6 +356,12 @@ pub fn lookup_all_framed_ip_address(packet: &Packet) -> Result<Vec<Ipv4Addr>, AV
         vec.push(avp.encode_ipv4()?)
     }
     Ok(vec)
+}
+
+/// Add `vsa_attribute` vsa value to a packet.
+pub fn add_vsa_attribute(packet: &mut Packet, value: &VSA) {
+    // packet.add(AVP::from_ipv4(FRAMED_IP_ADDRESS_TYPE, value));
+    packet.add(AVP::from_bytes(VENDOR_SPECIFIC_TYPE, &value.message()));
 }
 
 pub const FRAMED_IP_NETMASK_TYPE: AVPType = 9;

--- a/radius/src/core/vsa.rs
+++ b/radius/src/core/vsa.rs
@@ -1,0 +1,35 @@
+const SINGLE_FIELDS_COUNT: usize = 3;
+
+/// This struct represents a attribute-value pair.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VSA {
+    vendor_id: Vec<u8>,
+    type_id: u8,
+    length: u8,
+    tag: u8,
+    value: Vec<u8>,
+}
+
+impl VSA {
+    pub fn new(vendor_id: i32, type_id: u8, tag: u8, value: &str) -> VSA {
+        VSA {
+            vendor_id: vendor_id.to_be_bytes().to_vec(),
+            type_id,
+            length: (SINGLE_FIELDS_COUNT + value.len()) as u8,
+            tag: tag,
+            value: value.as_bytes().to_vec(),
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    pub fn message(&self) -> Vec<u8> {
+        let mut msg = vec![self.type_id, self.length, self.tag];
+        msg.splice(0..0, self.vendor_id.iter().cloned());
+        msg.append(&mut self.value.clone());
+
+        msg
+    }
+}


### PR DESCRIPTION
Hi,
As I see, there is no built-in functionality to add additional vendor specific attributes.
I create one by myself, so what about to accept this little improvement.
To add new VSA type we can use this example.

    use radius::core::vsa::VSA;
    use radius::core::rfc2865::add_vsa_attribute;
    ...
    // 4874 - Vendor Juniper ID
    // 65 - vsa type
    // 5 is tag number. i.e. in the world of Juniper Subscriber Manager router receives ERX-Service-Activate:5
    // value is some test string here
    let new_vsa = VSA::new(4874, 65, 5, "bar(1000,5441)");
    add_vsa_attribute(&mut p, &new_vsa);
