### PR TITLE
Refactor VSA

### DIFF
--- a/radius/src/core/rfc2865.rs
+++ b/radius/src/core/rfc2865.rs
@@ -360,7 +360,6 @@ pub fn lookup_all_framed_ip_address(packet: &Packet) -> Result<Vec<Ipv4Addr>, AV
 
 /// Add `vsa_attribute` vsa value to a packet.
 pub fn add_vsa_attribute(packet: &mut Packet, value: &VSA) {
-    // packet.add(AVP::from_ipv4(FRAMED_IP_ADDRESS_TYPE, value));
     packet.add(AVP::from_bytes(VENDOR_SPECIFIC_TYPE, &value.message()));
 }
 

--- a/radius/src/core/rfc2865.rs
+++ b/radius/src/core/rfc2865.rs
@@ -359,7 +359,7 @@ pub fn lookup_all_framed_ip_address(packet: &Packet) -> Result<Vec<Ipv4Addr>, AV
 }
 
 /// Add `vsa_attribute` vsa value to a packet.
-pub fn add_vsa_attribute(packet: &mut Packet, value: &VSA) {
+pub fn add_vsa_attribute(packet: &mut Packet, value: &dyn VSA) {
     packet.add(AVP::from_bytes(VENDOR_SPECIFIC_TYPE, &value.message()));
 }
 

--- a/radius/src/core/vsa.rs
+++ b/radius/src/core/vsa.rs
@@ -16,7 +16,7 @@ impl VSA {
             vendor_id: vendor_id.to_be_bytes().to_vec(),
             type_id,
             length: (SINGLE_FIELDS_COUNT + value.len()) as u8,
-            tag: tag,
+            tag,
             value: value.as_bytes().to_vec(),
         }
     }
@@ -26,10 +26,43 @@ impl VSA {
     }
 
     pub fn message(&self) -> Vec<u8> {
-        let mut msg = vec![self.type_id, self.length, self.tag];
-        msg.splice(0..0, self.vendor_id.iter().cloned());
-        msg.append(&mut self.value.clone());
+        let total_length: usize = SINGLE_FIELDS_COUNT + &self.vendor_id.len() + &self.value.len();
+        let mut result = Vec::with_capacity(total_length);
 
-        msg
+        result.extend(&self.vendor_id);
+        result.extend(vec![self.type_id, self.length, self.tag]);
+        result.extend(&self.value);
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::core::vsa::VSA;
+
+    #[test]
+    fn it_should_get_len_successfully() {
+        let vendor_id = 4874;
+        let vsa_type = 65;
+        let tag = 5;
+        let value = "bar(1000,5441)";
+        let vsa = VSA::new(vendor_id, vsa_type, tag, value);
+
+        assert_eq!(vsa.len(), 17);
+    }
+
+    #[test]
+    fn it_should_get_message_successfully() {
+        let vendor_id = 4874;
+        let vsa_type = 65;
+        let tag = 5;
+        let value = "bar(1000,5441)";
+        let vsa = VSA::new(vendor_id, vsa_type, tag, value);
+
+        assert_eq!(
+            vsa.message(),
+            [0, 0, 19, 10, 65, 17, 5, 98, 97, 114, 40, 49, 48, 48, 48, 44, 53, 52, 52, 49, 41]
+        )
     }
 }

--- a/radius/src/core/vsa.rs
+++ b/radius/src/core/vsa.rs
@@ -1,11 +1,71 @@
-const SINGLE_FIELDS_COUNT: usize = 3;
-
 /// VSA trait represents the general vendor-specific struct related methods.
 pub trait VSA {
     /// len returns the length of sub-attribute of vendor-specific.
     fn len(&self) -> usize;
     /// message returns the serialized vendor-specific message for AVP.
     fn message(&self) -> Vec<u8>;
+}
+
+/// StringVSA represents the VSA according to the RFC 2865.
+#[derive(Debug, Clone, PartialEq)]
+pub struct StringVSA {
+    vendor_id: Vec<u8>,
+    type_id: u8,
+    length: u8,
+    value: Vec<u8>,
+}
+
+impl StringVSA {
+    const BYTE_SIZE_OFFSET: usize = 2;
+
+    pub fn new(vendor_id: i32, type_id: u8, value: &str) -> StringVSA {
+        StringVSA {
+            vendor_id: vendor_id.to_be_bytes().to_vec(),
+            type_id,
+            /*
+             * Ref: RFC 4679 - https://datatracker.ietf.org/doc/html/rfc4679
+             * > Vendor-Length
+             * >
+             * >   The Vendor-Length field is one octet and indicates the length of
+             * >   the entire sub-attribute, including the Vendor-Type,
+             * >   Vendor-Length, and Value fields.
+             */
+            length: (Self::BYTE_SIZE_OFFSET + value.len()) as u8,
+            value: value.as_bytes().to_vec(),
+        }
+    }
+}
+
+impl VSA for StringVSA {
+    fn len(&self) -> usize {
+        self.length as usize
+    }
+
+    /// message returns the serialized vendor-specific message for AVP.
+    ///
+    /// Format:
+    ///    0                   1                   2                   3
+    ///    0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    ///   |    Type       |  Length       |            Vendor-Id
+    ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    ///        Vendor-Id (cont)           | Vendor type   | Vendor length |
+    ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    ///   |    Attribute-Specific...
+    ///   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-
+    ///
+    /// See also: RFC 2865 - https://datatracker.ietf.org/doc/html/rfc2865
+    fn message(&self) -> Vec<u8> {
+        let total_length: usize =
+            Self::BYTE_SIZE_OFFSET + &self.vendor_id.len() + &self.value.len();
+        let mut result = Vec::with_capacity(total_length);
+
+        result.extend(&self.vendor_id);
+        result.extend(vec![self.type_id, self.length]);
+        result.extend(&self.value);
+
+        result
+    }
 }
 
 /// TaggedStringVSA represents the VSA which has a tag value.
@@ -19,11 +79,21 @@ pub struct TaggedStringVSA {
 }
 
 impl TaggedStringVSA {
+    const BYTE_SIZE_OFFSET: usize = 3;
+
     pub fn new(vendor_id: i32, type_id: u8, tag: u8, value: &str) -> TaggedStringVSA {
         TaggedStringVSA {
             vendor_id: vendor_id.to_be_bytes().to_vec(),
             type_id,
-            length: (SINGLE_FIELDS_COUNT + value.len()) as u8,
+            /*
+             * Ref: RFC 4679 - https://datatracker.ietf.org/doc/html/rfc4679
+             * > Vendor-Length
+             * >
+             * >   The Vendor-Length field is one octet and indicates the length of
+             * >   the entire sub-attribute, including the Vendor-Type,
+             * >   Vendor-Length, and Value fields.
+             */
+            length: (Self::BYTE_SIZE_OFFSET + value.len()) as u8,
             tag,
             value: value.as_bytes().to_vec(),
         }
@@ -31,14 +101,6 @@ impl TaggedStringVSA {
 }
 
 impl VSA for TaggedStringVSA {
-    /// len returns the length of sub-attribute of vendor-specific.
-    ///
-    /// Ref: RFC4679 - https://datatracker.ietf.org/doc/html/rfc4679
-    /// > Vendor-Length
-    /// >
-    /// >   The Vendor-Length field is one octet and indicates the length of
-    /// >   the entire sub-attribute, including the Vendor-Type,
-    /// >   Vendor-Length, and Value fields.
     fn len(&self) -> usize {
         self.length as usize
     }
@@ -58,7 +120,8 @@ impl VSA for TaggedStringVSA {
     ///
     /// See also: CISCO RADIUS Attributes Configuration Guide - https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_radatt/configuration/xe-16/sec-usr-radatt-xe-16-book.pdf
     fn message(&self) -> Vec<u8> {
-        let total_length: usize = SINGLE_FIELDS_COUNT + &self.vendor_id.len() + &self.value.len();
+        let total_length: usize =
+            Self::BYTE_SIZE_OFFSET + &self.vendor_id.len() + &self.value.len();
         let mut result = Vec::with_capacity(total_length);
 
         result.extend(&self.vendor_id);
@@ -66,6 +129,34 @@ impl VSA for TaggedStringVSA {
         result.extend(&self.value);
 
         result
+    }
+}
+
+#[cfg(test)]
+mod string_vsa_tests {
+    use crate::core::vsa::{StringVSA, VSA};
+
+    #[test]
+    fn it_should_get_len_successfully() {
+        let vendor_id = 4874;
+        let vsa_type = 65;
+        let value = "bar(1000,5441)";
+        let vsa = StringVSA::new(vendor_id, vsa_type, value);
+
+        assert_eq!(vsa.len(), 16);
+    }
+
+    #[test]
+    fn it_should_get_message_successfully() {
+        let vendor_id = 4874;
+        let vsa_type = 65;
+        let value = "bar(1000,5441)";
+        let vsa = StringVSA::new(vendor_id, vsa_type, value);
+
+        assert_eq!(
+            vsa.message(),
+            [0, 0, 19, 10, 65, 16, 98, 97, 114, 40, 49, 48, 48, 48, 44, 53, 52, 52, 49, 41]
+        )
     }
 }
 

--- a/radius/src/core/vsa.rs
+++ b/radius/src/core/vsa.rs
@@ -10,7 +10,7 @@ pub trait VSA {
 #[derive(Debug, Clone, PartialEq)]
 pub struct StringVSA {
     vendor_id: Vec<u8>,
-    type_id: u8,
+    vendor_type: u8,
     length: u8,
     value: Vec<u8>,
 }
@@ -18,10 +18,10 @@ pub struct StringVSA {
 impl StringVSA {
     const BYTE_SIZE_OFFSET: usize = 2;
 
-    pub fn new(vendor_id: i32, type_id: u8, value: &str) -> StringVSA {
+    pub fn new(vendor_id: i32, vendor_type: u8, value: &str) -> StringVSA {
         StringVSA {
             vendor_id: vendor_id.to_be_bytes().to_vec(),
-            type_id,
+            vendor_type,
             /*
              * Ref: RFC 4679 - https://datatracker.ietf.org/doc/html/rfc4679
              * > Vendor-Length
@@ -61,7 +61,7 @@ impl VSA for StringVSA {
         let mut result = Vec::with_capacity(total_length);
 
         result.extend(&self.vendor_id);
-        result.extend(vec![self.type_id, self.length]);
+        result.extend(vec![self.vendor_type, self.length]);
         result.extend(&self.value);
 
         result
@@ -72,7 +72,7 @@ impl VSA for StringVSA {
 #[derive(Debug, Clone, PartialEq)]
 pub struct TaggedStringVSA {
     vendor_id: Vec<u8>,
-    type_id: u8,
+    vendor_type: u8,
     length: u8,
     tag: u8,
     value: Vec<u8>,
@@ -81,10 +81,10 @@ pub struct TaggedStringVSA {
 impl TaggedStringVSA {
     const BYTE_SIZE_OFFSET: usize = 3;
 
-    pub fn new(vendor_id: i32, type_id: u8, tag: u8, value: &str) -> TaggedStringVSA {
+    pub fn new(vendor_id: i32, vendor_type: u8, tag: u8, value: &str) -> TaggedStringVSA {
         TaggedStringVSA {
             vendor_id: vendor_id.to_be_bytes().to_vec(),
-            type_id,
+            vendor_type,
             /*
              * Ref: RFC 4679 - https://datatracker.ietf.org/doc/html/rfc4679
              * > Vendor-Length
@@ -125,7 +125,7 @@ impl VSA for TaggedStringVSA {
         let mut result = Vec::with_capacity(total_length);
 
         result.extend(&self.vendor_id);
-        result.extend(vec![self.type_id, self.length, self.tag]);
+        result.extend(vec![self.vendor_type, self.length, self.tag]);
         result.extend(&self.value);
 
         result

--- a/radius/src/core/vsa.rs
+++ b/radius/src/core/vsa.rs
@@ -1,7 +1,16 @@
 /// VSA trait represents the general vendor-specific struct related methods.
 pub trait VSA {
     /// len returns the length of sub-attribute of vendor-specific.
+    ///
+    /// Ref: RFC 4679 - https://datatracker.ietf.org/doc/html/rfc4679
+    /// > Vendor-Length
+    /// >
+    /// >   The Vendor-Length field is one octet and indicates the length of
+    /// >   the entire sub-attribute, including the Vendor-Type,
+    /// >   Vendor-Length, and Value fields.
     fn len(&self) -> usize;
+    /// is_empty returns whether the VSA is empty or not.
+    fn is_empty(&self) -> bool;
     /// message returns the serialized vendor-specific message for AVP.
     fn message(&self) -> Vec<u8>;
 }
@@ -41,6 +50,10 @@ impl VSA for StringVSA {
         self.length as usize
     }
 
+    fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
     /// message returns the serialized vendor-specific message for AVP.
     ///
     /// Format:
@@ -56,8 +69,7 @@ impl VSA for StringVSA {
     ///
     /// See also: RFC 2865 - https://datatracker.ietf.org/doc/html/rfc2865
     fn message(&self) -> Vec<u8> {
-        let total_length: usize =
-            Self::BYTE_SIZE_OFFSET + &self.vendor_id.len() + &self.value.len();
+        let total_length: usize = Self::BYTE_SIZE_OFFSET + self.vendor_id.len() + self.value.len();
         let mut result = Vec::with_capacity(total_length);
 
         result.extend(&self.vendor_id);
@@ -105,6 +117,10 @@ impl VSA for TaggedStringVSA {
         self.length as usize
     }
 
+    fn is_empty(&self) -> bool {
+        self.length == 0
+    }
+
     /// message returns the serialized vendor-specific message for AVP.
     ///
     /// Format:
@@ -120,8 +136,7 @@ impl VSA for TaggedStringVSA {
     ///
     /// See also: CISCO RADIUS Attributes Configuration Guide - https://www.cisco.com/c/en/us/td/docs/ios-xml/ios/sec_usr_radatt/configuration/xe-16/sec-usr-radatt-xe-16-book.pdf
     fn message(&self) -> Vec<u8> {
-        let total_length: usize =
-            Self::BYTE_SIZE_OFFSET + &self.vendor_id.len() + &self.value.len();
+        let total_length: usize = Self::BYTE_SIZE_OFFSET + self.vendor_id.len() + self.value.len();
         let mut result = Vec::with_capacity(total_length);
 
         result.extend(&self.vendor_id);


### PR DESCRIPTION
Extends https://github.com/moznion/radius-rs/pull/37

- Add test cases for VSA
- VSA becomes a trait, instead of the struct
  - previous `VSA` structure renamed to `TaggedStringVSA`
  - and `StringVSA` which doesn't have a tag byte is added